### PR TITLE
[SBI #14] stg環境方針の決定と各環境プレビュー確認方法のドキュメント化

### DIFF
--- a/.claude/skills/sbi-pr-create/SKILL.md
+++ b/.claude/skills/sbi-pr-create/SKILL.md
@@ -14,10 +14,11 @@ description: push済みのブランチから .github/pull_request_template.md �
    - `Closes #<SBI番号>` / `関連PBI: #<PBI番号>`
    - 変更内容・動作確認内容は実際に行った内容のみを書く
    - DoDチェックリストは実際に確認できた項目だけチェックし、未確認の項目は空欄のまま残す
-5. `gh pr create --title "..." --body "..."` で作成し、URLを報告する。`claude-code-review` ワークフローが自動でレビューコメントを投稿する旨も伝える。
+5. `gh pr create --base develop --title "..." --body "..."` で作成し、URLを報告する。`claude-code-review` ワークフローが自動でレビューコメントを投稿する旨も伝える。
 6. PR作成で止まる。マージは行わない（マージはユーザー自身、または明示の指示があるときのみ）。
 
 ## Fail-safe
 
 - SBI issueが特定できない/紐づくPBIが不明な場合は、Closes行を空欄のまま作成せずユーザーに確認する。
 - 対象ブランチがmain/developの場合はPRを作成しない（作業ブランチが無い状態のため、先にブランチを切るべきか確認する）。
+- `Closes #` はリポジトリのデフォルトブランチ（`main`）へのマージでしか自動発火しない。SBI PRは`develop`向けなので、マージされてもissueは自動クローズされない。マージ報告を受けたら手動で `gh issue close <SBI番号>` する（PR作成時点ではなく、マージ確認後の作業）。

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,0 +1,37 @@
+# 環境構成（dev / stg / prod）
+
+shift-appの環境は **dev（PRごとのプレビュー）/ stg（`develop`ブランチ）/ prod（`main`ブランチ）** の3段階とする。
+
+## 1. 方針: stg環境は独立させず、`develop`ブランチをstg兼dev基盤として扱う
+
+- Renderの無料プランでは、単一サービスの「PR Previews（Service Previews）」はベースサービスと同じ課金レートで動く。ベースのWebサービス（backend）が無料プランなら、そのPR previewも無料。
+- 一方、DBを含む複数サービスをまるごと複製する「Preview Environments」（Blueprintベース）はフル機能を使うには実質有料ワークスペース（Proプラン, $25/月〜）が前提になる。DB込みの独立stg環境を作るとコストが発生する。
+- 現状は開発者1名でコストをかけられる段階でもないため、**独立したstg環境（別Renderサービス・別DB）は持たない**。代わりに以下の2層構成で運用する。
+  - **dev**: SBIのPRごとに、Vercel/Renderが自動生成するプレビュー環境で確認する。
+  - **stg**: `develop`ブランチに複数のSBIがマージされた状態を、`develop`を継続デプロイしている環境（Vercelのブランチデプロイ + Renderの`develop`追跡サービス）で確認する。実質的に「マージ後の結合確認用の共有環境」としてstgを兼ねる。
+  - **prod**: `main`ブランチ。本番。
+- 開発体制が拡大し、DB分離やチーム間の同時並行検証が必要になったタイミングで、独立したstg環境（別Renderサービス+別DB、Proワークスペースへの切り替え）を再検討する。
+
+## 2. 各環境のプレビュー確認方法
+
+### dev（PRごとのプレビュー）
+
+- **フロントエンド（Vercel）**: PRを作成すると、Vercelが自動でプレビューデプロイを作成し、PRにコメントでURLを投稿する。URLの形式は `https://shift-app-<hash>-taiseis-projects-dc838d86.vercel.app`（コミットごと）。
+- **バックエンド（Render）**: Renderのサービス設定で「PR Previews」を有効化しておくと、PRごとにbackendサービスのプレビューが自動作成される（backendが無料プランのWebサービスなら追加料金なし）。**未設定の場合はRenderダッシュボードでの手動設定が必要**（このSBIの範囲では未設定。設定はSBI外のインフラ作業として別途行う）。
+- 注意: dev previewのbackendはDBを分離しない想定（本番/developと同じDBに接続する）。PRでのテストデータ投入・削除は既存データに影響しうるため、破壊的な操作を伴う確認は避ける。
+
+### stg（`develop`ブランチ）
+
+- **フロントエンド（Vercel）**: `develop`にpushされるたびに、Vercelのブランチデプロイが更新される。URLは `https://shift-app-git-develop-taiseis-projects-dc838d86.vercel.app`。
+- **バックエンド（Render）**: `develop`ブランチを追跡するRenderサービスを使う（本番サービスとは別サービスとして、`develop`ブランチを自動デプロイ対象に設定する。**未作成の場合は作成が必要**、このSBIの範囲では未確認）。
+- 人間レビュー前後の結合確認・デモ用に使う。
+
+### prod（`main`ブランチ）
+
+- **フロントエンド（Vercel）**: `main`へのマージで本番URLに反映される。
+- **バックエンド（Render）**: `main`を追跡する本番Renderサービス + Render PostgreSQL。
+
+## 3. 未確認・要フォローアップ
+
+- Renderダッシュボード側で、backendサービスの「PR Previews」トグルが現在有効になっているかは未確認（Render管理画面での確認が必要）。
+- `develop`ブランチを追跡する独立したRenderサービスが既に存在するか未確認。無ければ新規作成が必要（追加のRenderサービス1つ分のリソースを消費するが、無料プランの範囲内であれば追加コストなし）。

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -3,6 +3,8 @@
 shift-appの開発は、プロダクトバックログを **PBI → SBI** に分解して進めるスクラム駆動開発を採用する。
 各フェーズでClaudeを活用する **AIDLC (AI-Driven Development Life Cycle)** の考え方に基づき、バックログ分解・実装・レビューにAIを組み込む。
 
+環境構成（dev/stg/prod）とプレビュー確認方法は [docs/environments.md](environments.md) を参照。
+
 ## 1. PBI / SBI の定義
 
 - **PBI (Product Backlog Item)**: ユーザーに価値をもたらす機能単位。README「今後の実装予定」やヒアリングから積む。ブランチは持たない。

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -16,9 +16,9 @@ PBI issueには `type:pbi`、SBI issueには `type:sbi` ラベルを付与する
 2. **スプリントプランニング**: PBIをSBIに分解する。分解の壁打ちにClaudeを使ってよい（AIDLCの「Intent capture → Unit-level design」フェーズ）。各SBIは `[SBI] ` テンプレートで起票し、親PBI番号を紐づける。PBI側の「関連SBI」欄にもチェックリストとして追記する。
 3. **ブランチ作成**: SBI issueから `{issue番号}-{kebab-caseの概要}` の名前でブランチを切る（例: `13-position-capacity`）。
 4. **実装**: Claude Codeとのペアプロで実装を進める。SBIのDefinition of Doneを満たすまで作業する。
-5. **PR作成**: `.github/pull_request_template.md` に従い、`Closes #<SBI番号>` を含めてPRを作成する。PR作成・更新をトリガーに `claude-code-review` ワークフローが自動でレビューコメントを投稿する。
+5. **PR作成**: SBIブランチから **`develop` 向けに** `.github/pull_request_template.md` に従い、`Closes #<SBI番号>` を含めてPRを作成する。PR作成・更新をトリガーに `claude-code-review` ワークフローが自動でレビューコメントを投稿する。
 6. **人間レビュー**: Claudeの自動レビューコメントを確認し、必要な修正を行う。人間のレビュアーが最終承認する。
-7. **マージ**: マージ後、SBI issueは自動クローズ（`Closes #`）される。すべての子SBIがクローズされたら、PBI issueを手動でクローズする。
+7. **マージ**: `develop` にマージする。GitHubの `Closes #` はリポジトリのデフォルトブランチ（`main`）へのマージでしか自動発火しないため、`develop` へのマージではSBI issueは自動クローズされない。マージ後に手動で `gh issue close <SBI番号>` する。すべての子SBIがクローズされたら、PBI issueを手動でクローズする。`develop` から `main` へのリリースマージ時には、そこに含まれるSBI issueの `Closes #` が自動発火する場合がある（すでに手動クローズ済みなら影響なし）。
 
 ## 3. ブランチ命名規約
 


### PR DESCRIPTION
## 関連Issue

Closes #14
関連PBI: #12

## 変更内容

- `docs/environments.md` を新規作成
  - Render無料プランのPR Preview対応状況を調査（単一サービスのService Previewsはベースサービスと同レート課金＝無料プランなら無料。DB込みのフル`Preview Environments`はBlueprint必須で実質有料プラン前提）
  - stg方針を決定: 独立したstg環境（別Renderサービス・別DB）は持たず、`develop`ブランチをstg兼dev基盤として扱う
  - dev/stg/prodそれぞれのプレビュー確認方法（Vercelのブランチ/PRプレビューURL、Renderのbackend環境の扱い）を整理
  - Renderダッシュボード側で未確認の項目（PR Previewsトグルの有効化状況、develop追跡サービスの有無）を「要フォローアップ」として明記
- `docs/workflow.md` に `docs/environments.md` へのリンクを追加
- （持ち越し分）`Closes #` はdevelopへのマージでは自動発火しない（デフォルトブランチ=mainへのマージでしか発火しない）ことをSBI #13で確認したため、`docs/workflow.md` と `sbi-pr-create` スキルに手動クローズ運用を明記

## 動作確認内容

- Render公式ドキュメント(pull-request-previews)をWebFetchで調査し、無料プランでのPR Preview課金条件を確認
- 既存のCORS設定・READMEのインフラ記載と整合していることを確認

## DoDチェックリスト

- [x] SBIのDefinition of Doneを満たしている
- [x] 動作確認済み
- [ ] UI変更を含む場合、docs/design.md の配色・角丸・shadow・余白・タイポグラフィ規約に従っている（該当なし）
- [x] テキストに絵文字を使用していない
- [ ] Claude自動レビュー（`claude-code-review` ワークフロー）のコメントを確認し、指摘事項に対応または妥当性を判断した