### PR TITLE
[SBI #15] 不要な旧ブランチ(demo1, demo2)の整理

### DIFF
--- a/.claude/skills/sbi-pr-create/SKILL.md
+++ b/.claude/skills/sbi-pr-create/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: sbi-pr-create
-description: push済みのブランチから .github/pull_request_template.md に沿ってPRを作成する（コミットやpushは行わない）。TRIGGER — 「PR作って」「PR出して」など、PR作成だけを頼まれたとき。SKIP: 未pushの変更がある場合は先に sbi-push で確認してからこのスキルを使う。
+description: push済みのブランチから .github/pull_request_template.md に沿ってPRを作成する（コミットやpushは行わない）。また、ユーザーから「マージした」と報告されたときのマージ後フォローアップ（ローカルdevelop同期・issue close・PBIチェックリスト更新）もこのスキルの範囲。TRIGGER — 「PR作って」「PR出して」などPR作成を頼まれたとき、または「マージした」とマージ完了を報告されたとき。SKIP: 未pushの変更がある場合は先に sbi-push で確認してからこのスキルを使う。
 ---
 
-# SBI PR作成
+# SBI PR作成とマージ後フォローアップ
 
-## 実行契約
+## PR作成の実行契約
 
 1. `git status` で現在のブランチがpush済みか確認する。未pushのコミットがあればユーザーに確認する（push自体は sbi-push の範囲）。
 2. 紐づくSBI issue番号から `gh issue view <SBI番号>` で親PBI番号を取得する。
@@ -17,8 +17,17 @@ description: push済みのブランチから .github/pull_request_template.md �
 5. `gh pr create --base develop --title "..." --body "..."` で作成し、URLを報告する。`claude-code-review` ワークフローが自動でレビューコメントを投稿する旨も伝える。
 6. PR作成で止まる。マージは行わない（マージはユーザー自身、または明示の指示があるときのみ）。
 
+## マージ後フォローアップの実行契約
+
+ユーザーから「マージした」と報告されたら、`gh pr view <PR番号> --json state,mergedAt` でマージ済みを確認したうえで、以下を行う（[docs/workflow.md](../../../docs/workflow.md) 2章7参照）。
+
+1. `git checkout develop && git pull` でローカルの `develop` をリモートに追従させる（GitHub側で既にマージ済みのため、ローカルで改めて `git merge` する必要はない。pullでfast-forwardするだけでよい）。
+2. `Closes #` はデフォルトブランチ（`main`）へのマージでしか自動発火しないため、`develop` へのマージではSBI issueは自動クローズされない。`gh issue close <SBI番号>` で手動クローズする。
+3. 親PBI issueの「関連SBI」チェックリストで該当SBIにチェックを付ける（`gh issue edit`）。すべての子SBIがクローズされたら、PBI issue自体を手動でクローズしてよいか確認する。
+4. マージ済みのローカル作業ブランチを `git branch -d <branch>` で削除する（安全のためmergeされていないと削除できないコマンドを使う。`-D` は使わない）。リモート側はリポジトリ設定 `Automatically delete head branches` により自動削除されるため、`git push origin --delete` は不要。
+
 ## Fail-safe
 
 - SBI issueが特定できない/紐づくPBIが不明な場合は、Closes行を空欄のまま作成せずユーザーに確認する。
 - 対象ブランチがmain/developの場合はPRを作成しない（作業ブランチが無い状態のため、先にブランチを切るべきか確認する）。
-- `Closes #` はリポジトリのデフォルトブランチ（`main`）へのマージでしか自動発火しない。SBI PRは`develop`向けなので、マージされてもissueは自動クローズされない。マージ報告を受けたら手動で `gh issue close <SBI番号>` する（PR作成時点ではなく、マージ確認後の作業）。
+- マージ後フォローアップの手順1を飛ばすと、ローカル`develop`が古いままになり、次のSBIブランチを誤って古い地点から切ってしまう（実際に発生した事故）。マージ報告を受けたら必ずこの手順を実行する。

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -16,11 +16,16 @@ PBI issueには `type:pbi`、SBI issueには `type:sbi` ラベルを付与する
 
 1. **PBI起票**: `[PBI] ` テンプレートでissueを作成し、ユーザーストーリー・受け入れ条件・優先度を書く。
 2. **スプリントプランニング**: PBIをSBIに分解する。分解の壁打ちにClaudeを使ってよい（AIDLCの「Intent capture → Unit-level design」フェーズ）。各SBIは `[SBI] ` テンプレートで起票し、親PBI番号を紐づける。PBI側の「関連SBI」欄にもチェックリストとして追記する。
-3. **ブランチ作成**: SBI issueから `{issue番号}-{kebab-caseの概要}` の名前でブランチを切る（例: `13-position-capacity`）。
+3. **ブランチ作成**: 最新化した `develop`（後述7を終えた状態）から、SBI issueに対応する `{issue番号}-{kebab-caseの概要}` の名前でブランチを切る（例: `13-position-capacity`）。古いブランチのHEADから続けて切ると履歴が枝分かれしたまま進むため避ける。
 4. **実装**: Claude Codeとのペアプロで実装を進める。SBIのDefinition of Doneを満たすまで作業する。
 5. **PR作成**: SBIブランチから **`develop` 向けに** `.github/pull_request_template.md` に従い、`Closes #<SBI番号>` を含めてPRを作成する。PR作成・更新をトリガーに `claude-code-review` ワークフローが自動でレビューコメントを投稿する。
 6. **人間レビュー**: Claudeの自動レビューコメントを確認し、必要な修正を行う。人間のレビュアーが最終承認する。
-7. **マージ**: `develop` にマージする。GitHubの `Closes #` はリポジトリのデフォルトブランチ（`main`）へのマージでしか自動発火しないため、`develop` へのマージではSBI issueは自動クローズされない。マージ後に手動で `gh issue close <SBI番号>` する。すべての子SBIがクローズされたら、PBI issueを手動でクローズする。`develop` から `main` へのリリースマージ時には、そこに含まれるSBI issueの `Closes #` が自動発火する場合がある（すでに手動クローズ済みなら影響なし）。
+7. **マージ後の後始末**: `develop` にマージする（マージ自体はGitHub上で完結する）。マージが確認できたら、必ず以下を行ってから次のSBIに進む。
+   - ローカルで `git checkout develop && git pull` し、リモートに追従させる（**ローカルで改めて `git merge` する必要はない**。GitHub側で既にマージ済みのため、pullでfast-forwardするだけでよい）。これを飛ばすとローカルの`develop`だけ取り残され、次のブランチを古い地点から切ってしまう。
+   - リモートのSBIブランチはリポジトリ設定 `Automatically delete head branches`（ON済み）によりマージ後に自動削除される。ローカルのSBIブランチは `git branch -d <branch>` で手動削除する。
+   - GitHubの `Closes #` はリポジトリのデフォルトブランチ（`main`）へのマージでしか自動発火しないため、`develop` へのマージではSBI issueは自動クローズされない。手動で `gh issue close <SBI番号>` する。
+   - すべての子SBIがクローズされたら、PBI issueを手動でクローズする。
+   - `develop` から `main` へのリリースマージ時には、そこに含まれるSBI issueの `Closes #` が自動発火する場合がある（すでに手動クローズ済みなら影響なし）。
 
 ## 3. ブランチ命名規約
 


### PR DESCRIPTION
## 関連Issue

Closes #15
関連PBI: #12

## 変更内容

- `demo1`, `demo2` ブランチの内容を調査（`develop`/`main`双方に完全に含まれており未マージの差分なし、設定ファイル等からの参照もなし）→ アーカイブ不要と判断しローカル・リモート双方から削除
- ついでに、既にマージ済みで残っていたリモートブランチ（`13-branch-protection`, `14-env-preview-docs`, `vercel/react-server-components-cve-vu-yh2hlu`）と、リネーム前の古いブランチ名の失効したローカル参照（`origin/#13-branch-protection`, `git fetch --prune`で解消）も削除
- リポジトリ設定 `Automatically delete head branches` をONにし、今後PRマージ時にリモートブランチが自動削除されるようにした
- マージ後フォローアップ手順（`git checkout develop && git pull`でローカル同期、`Closes #`がdevelopマージでは自動発火しない問題への対応、ローカルブランチ削除）を `docs/workflow.md` と `sbi-pr-create` スキルに明文化（SBI #13, #14の作業中に判明した運用ギャップの是正）

## 動作確認内容

- `git log develop..demo1` 等で差分がないことを確認済み
- `git ls-remote --heads origin` でリモートブランチが `develop`/`main` のみになったことを確認済み
- `gh api repos/taisei0719/shift-app -q '{delete_branch_on_merge: .delete_branch_on_merge}'` で `true` になったことを確認済み

## DoDチェックリスト

- [x] SBIのDefinition of Doneを満たしている
- [x] 動作確認済み
- [ ] UI変更を含む場合、docs/design.md の配色・角丸・shadow・余白・タイポグラフィ規約に従っている（該当なし）
- [x] テキストに絵文字を使用していない
- [ ] Claude自動レビュー（`claude-code-review` ワークフロー）のコメントを確認し、指摘事項に対応または妥当性を判断した