### PR TITLE
[SBI #26] shop_register経由の店舗登録〜シフト機能利用を一連で動くよう修正

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -284,8 +284,8 @@ def register():
     }
     
     # 2. アクセストークンを生成
-    access_token = create_access_token(identity=str(user.id)) 
-    
+    access_token = create_access_token(identity=str(user.id), fresh=True)
+
     # 2. レスポンスオブジェクトを作成
     response = jsonify({
         "message": "登録成功",
@@ -412,11 +412,11 @@ def login():
         }
         
         # 2. アクセストークンを生成
-        access_token = create_access_token(identity=str(user.id)) 
+        access_token = create_access_token(identity=str(user.id), fresh=True)
 
         # 3. レスポンスオブジェクトを作成
-        response = jsonify({ 
-            "message": "ログイン成功", 
+        response = jsonify({
+            "message": "ログイン成功",
             "access_token": access_token, # モバイル/Webが保存するトークン
             "user": {
                 "user_name": user.name,
@@ -866,6 +866,7 @@ def shop_register():
     
     # 3. 管理者ユーザーの情報を更新
     admin_user = User.query.get(manager_id)
+    admin_user.shop_id = shop.id
     db.session.commit() # DBの変更をコミット
     
     # 4. 新しいshop_idを含むJWTペイロードを作成し、トークンを再発行する

--- a/backend/app.py
+++ b/backend/app.py
@@ -274,16 +274,8 @@ def register():
     db.session.commit() # ユーザーID (user.id) が確定する
 
     # ★★★ 登録成功後、JWTトークンを発行する ★★★
-    
-    # 1. JWTペイロードに保存する情報を定義
-    identity_data = {
-        "user_id": user.id,
-        "user_name": user.name,
-        "role": user.role,
-        "shop_id": user.shop_id # 登録直後は None になるはず
-    }
-    
-    # 2. アクセストークンを生成
+
+    # 1. アクセストークンを生成
     access_token = create_access_token(identity=str(user.id), fresh=True)
 
     # 2. レスポンスオブジェクトを作成
@@ -403,15 +395,7 @@ def login():
         # ユーザーに紐づく店舗名を取得 (user.shopがNoneの場合を安全にチェック)
         shop_name_val = user.shop.name if user.shop else None
         
-        # 1. JWTペイロードに保存する情報を定義
-        identity_data = {
-            "user_id": user.id,
-            "user_name": user.name,
-            "role": user.role,
-            "shop_id": user.shop_id
-        }
-        
-        # 2. アクセストークンを生成
+        # 1. アクセストークンを生成
         access_token = create_access_token(identity=str(user.id), fresh=True)
 
         # 3. レスポンスオブジェクトを作成
@@ -858,18 +842,18 @@ def shop_register():
     if Shop.query.filter_by(name=name).first():
         return jsonify({"error": "店舗名が既に存在します"}), 400
 
-    # 2. 店舗を登録
+    # 2. 店舗を登録（flushでshop.idだけ確定させ、まだコミットしない）
     code = Shop.generate_unique_code()
     shop = Shop(name=name, location=location, shop_code=code)
     db.session.add(shop)
-    db.session.commit() # 店舗のID (shop.id) を確定させる
-    
-    # 3. 管理者ユーザーの情報を更新
-    admin_user = User.query.get(manager_id)
+    db.session.flush()
+
+    # 3. 管理者ユーザーの情報を更新し、店舗作成とまとめて1トランザクションでコミットする
+    #    （分けてcommitすると、後段で例外が起きた際に店舗だけ作成された不整合データが残るため）
     admin_user.shop_id = shop.id
-    db.session.commit() # DBの変更をコミット
-    
-    # 4. 新しいshop_idを含むJWTペイロードを作成し、トークンを再発行する
+    db.session.commit()
+
+    # 4. DB更新後、クッキーにセットするアクセストークンを再発行する
     new_access_token = create_access_token(identity=str(admin_user.id), fresh=True) 
     new_refresh_token = create_refresh_token(identity=str(admin_user.id))
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -5,7 +5,7 @@ from werkzeug.security import generate_password_hash
 import secrets 
 import random, string
 from sqlalchemy.dialects.postgresql import JSON
-from datetime import datetime
+from datetime import datetime, time
 
 db = SQLAlchemy() 
 
@@ -52,8 +52,8 @@ class Shop(db.Model):
     name = db.Column(db.String(80), unique=True, nullable=False)
     location = db.Column(db.String(200), nullable=True)
     shop_code = db.Column(db.String(32), unique=True, nullable=False)
-    open_time = db.Column(db.Time, nullable=False, default=db.func.time(9, 0))
-    close_time = db.Column(db.Time, nullable=False, default=db.func.time(22, 0))
+    open_time = db.Column(db.Time, nullable=False, default=time(9, 0))
+    close_time = db.Column(db.Time, nullable=False, default=time(22, 0))
     
     @staticmethod
     def generate_unique_code():

--- a/backend/tests/test_shop_register.py
+++ b/backend/tests/test_shop_register.py
@@ -1,0 +1,76 @@
+from models import User
+
+
+def test_shop_register_sets_admin_shop_id(client, db_session, make_user, auth_header):
+    admin = make_user(email="owner@example.com", password="password123", role="admin", shop=None)
+    admin_id = admin.id
+    headers = auth_header("owner@example.com", "password123")
+
+    res = client.post(
+        "/api/shop_register",
+        headers=headers,
+        json={"name": "My Shop", "location": "Tokyo"},
+    )
+
+    assert res.status_code == 200
+    shop_id = res.get_json()["shop_id"]
+
+    updated_admin = db_session.get(User, admin_id)
+    assert updated_admin.shop_id == shop_id
+
+
+def test_shop_register_requires_admin_role(client, make_user, auth_header):
+    make_user(email="staffonly@example.com", password="password123", role="staff", shop=None)
+    headers = auth_header("staffonly@example.com", "password123")
+
+    res = client.post(
+        "/api/shop_register",
+        headers=headers,
+        json={"name": "Staff Shop", "location": "Osaka"},
+    )
+
+    assert res.status_code == 403
+
+
+def test_shop_register_rejects_duplicate_shop_name(client, make_shop, make_user, auth_header):
+    make_shop(name="Existing Shop")
+    make_user(email="owner2@example.com", password="password123", role="admin", shop=None)
+    headers = auth_header("owner2@example.com", "password123")
+
+    res = client.post(
+        "/api/shop_register",
+        headers=headers,
+        json={"name": "Existing Shop", "location": "Osaka"},
+    )
+
+    assert res.status_code == 400
+
+
+def test_register_to_shop_register_to_shift_submit_end_to_end(client):
+    """新規登録→ログイン→店舗登録→シフト提出までを、実際のAPI呼び出しのみで通す統合テスト。"""
+    register_res = client.post(
+        "/api/register",
+        json={"name": "Owner Taro", "email": "e2e-owner@example.com", "password": "password123", "role": "admin"},
+    )
+    assert register_res.status_code == 201
+
+    login_res = client.post(
+        "/api/login", json={"identifier": "e2e-owner@example.com", "password": "password123"}
+    )
+    assert login_res.status_code == 200
+    headers = {"Authorization": f"Bearer {login_res.get_json()['access_token']}"}
+
+    shop_res = client.post(
+        "/api/shop_register",
+        headers=headers,
+        json={"name": "E2E Shop", "location": "Tokyo"},
+    )
+    assert shop_res.status_code == 200
+
+    submit_res = client.post(
+        "/api/shifts/submit_request",
+        headers=headers,
+        json={"requests": [{"date": "2026-10-01", "start": "09:00", "end": "17:00"}]},
+    )
+    assert submit_res.status_code == 200
+    assert "1件登録しました" in submit_res.get_json()["message"]


### PR DESCRIPTION
## 関連Issue

Closes #26
関連PBI: #25

## 変更内容

当初のスコープ（shop_id未設定）を調査・テスト中に、同じコードパスをブロックする2つの追加バグを発見したため、まとめて修正しました。

1. **shop_idが未設定**（当初のスコープ）: `backend/app.py` の `shop_register` で、店舗作成後 `admin_user.shop_id = shop.id` を実際には設定していなかった
2. **fresh=Trueトークン不整合**: `/api/login`・`/api/register` が `fresh=False`（デフォルト）のトークンを発行しており、`@jwt_required(fresh=True)` を要求する `shop_register` が常に401になり、通常のログインフローでは到達不能だった → 両エンドポイントで `fresh=True` を発行するよう修正
3. **Shopモデルのデフォルト値が不正なSQL**: `backend/models.py` の `Shop.open_time`/`close_time` のデフォルトが `db.func.time(9, 0)` になっており、SQLite（おそらくPostgresでも）で解釈できず店舗作成自体が `NOT NULL constraint failed` で失敗していた → Python側の `datetime.time` オブジェクトによる素直なデフォルトに変更

## 動作確認内容

- `backend/tests/test_shop_register.py` を新規追加（4件）:
  - shop_register成功時にadmin_userのshop_idが正しく更新されることの確認
  - admin以外のロールで403になることの確認
  - 店舗名重複で400になることの確認
  - **新規登録→ログイン→店舗登録→シフト提出**まで実際のAPI呼び出しだけで通すend-to-end統合テスト
- 既存の13件と合わせて、クリーンなPython 3.11環境で計17件全てパスすることを確認済み（検証用環境は削除済み）

## DoDチェックリスト

- [x] SBIのDefinition of Doneを満たしている（当初スコープに加え、ブロックしていた関連バグも解消）
- [x] 動作確認済み
- [ ] UI変更を含む場合、docs/design.md の配色・角丸・shadow・余白・タイポグラフィ規約に従っている（該当なし）
- [x] テキストに絵文字を使用していない
- [ ] Claude自動レビュー（`claude-code-review` ワークフロー）のコメントを確認し、指摘事項に対応または妥当性を判断した（Copilot自動レビューで代替）