### PR TITLE
[SBI #29] frontend CIワークフロー（lint/typecheck/test）

### DIFF
--- a/.claude/skills/sbi-pr-create/SKILL.md
+++ b/.claude/skills/sbi-pr-create/SKILL.md
@@ -16,7 +16,7 @@ description: push済みのブランチから .github/pull_request_template.md �
    - DoDチェックリストは実際に確認できた項目だけチェックし、未確認の項目は空欄のまま残す
 5. `gh pr create --base develop --title "..." --body "..."` で作成し、URLを報告する。GitHub Copilot code reviewがPR作成・push毎に自動でレビューコメントを投稿する旨も伝える（深掘りが必要なら `/code-review` または `claude-code-review.yml` の手動実行）。
 6. PR作成直後に、今月のCopilot AI Credits消費量を確認して報告する:
-   `gh api "users/taisei0719/settings/billing/usage?year=<現在の年>&month=<現在の月>" -q '[.usageItems[] | select(.product=="copilot" and .sku=="Copilot AI Credits")] | (map(.quantity) | add) // 0'`
+   `gh api "users/$(gh api user -q .login)/settings/billing/usage?year=<現在の年>&month=<現在の月>" -q '[.usageItems[] | select(.product=="copilot" and .sku=="Copilot AI Credits")] | (map(.quantity) | add) // 0'`
    月200クレジットが上限（Copilot Studentプラン、additional usageはdisabled）。消費量が上限に近い（目安: 8割=160クレジット超）場合は、Copilot自動レビューが今月中に止まる可能性がある旨をユーザーに伝える。
 7. PR作成で止まる。マージは行わない（マージはユーザー自身、または明示の指示があるときのみ）。
 

--- a/.claude/skills/sbi-pr-create/SKILL.md
+++ b/.claude/skills/sbi-pr-create/SKILL.md
@@ -15,7 +15,10 @@ description: push済みのブランチから .github/pull_request_template.md �
    - 変更内容・動作確認内容は実際に行った内容のみを書く
    - DoDチェックリストは実際に確認できた項目だけチェックし、未確認の項目は空欄のまま残す
 5. `gh pr create --base develop --title "..." --body "..."` で作成し、URLを報告する。GitHub Copilot code reviewがPR作成・push毎に自動でレビューコメントを投稿する旨も伝える（深掘りが必要なら `/code-review` または `claude-code-review.yml` の手動実行）。
-6. PR作成で止まる。マージは行わない（マージはユーザー自身、または明示の指示があるときのみ）。
+6. PR作成直後に、今月のCopilot AI Credits消費量を確認して報告する:
+   `gh api "users/taisei0719/settings/billing/usage?year=<現在の年>&month=<現在の月>" -q '[.usageItems[] | select(.product=="copilot" and .sku=="Copilot AI Credits")] | (map(.quantity) | add) // 0'`
+   月200クレジットが上限（Copilot Studentプラン、additional usageはdisabled）。消費量が上限に近い（目安: 8割=160クレジット超）場合は、Copilot自動レビューが今月中に止まる可能性がある旨をユーザーに伝える。
+7. PR作成で止まる。マージは行わない（マージはユーザー自身、または明示の指示があるときのみ）。
 
 ## マージ後フォローアップの実行契約
 

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -1,7 +1,8 @@
 name: CI (frontend)
 
 # frontend配下の変更を含むPRの作成・更新をトリガーに、lint・型チェック・テストを自動実行する。
-# 現時点では失敗してもステータスが赤くなるだけでマージはブロックしない（docs/workflow.md 6章参照）。
+# 失敗時はステータスが赤くなる。マージをブロックしないためには、ブランチ保護（Required status checks）で
+# このワークフローを必須に設定しない（docs/workflow.md 6章参照）。
 
 on:
   pull_request:
@@ -9,6 +10,9 @@ on:
     paths:
       - "frontend/**"
       - ".github/workflows/ci-frontend.yml"
+
+permissions:
+  contents: read
 
 jobs:
   lint:

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -1,0 +1,57 @@
+name: CI (frontend)
+
+# frontend配下の変更を含むPRの作成・更新をトリガーに、lint・型チェック・テストを自動実行する。
+# 現時点では失敗してもステータスが赤くなるだけでマージはブロックしない（docs/workflow.md 6章参照）。
+
+on:
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/ci-frontend.yml"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm run typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm run test

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "build": "next build --no-lint",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {


### PR DESCRIPTION
## 関連Issue

Closes #29
関連PBI: #10

## 変更内容

- `frontend/package.json` に `typecheck`（`tsc --noEmit`）スクリプトを追加
- `.github/workflows/ci-frontend.yml` を新規作成。`frontend/**`変更を含むPRの作成・更新をトリガーに、lint/typecheck/testを並列ジョブで自動実行
- 既存コードのlint警告/エラー（32件）はこのSBIでは修正しない。マージを強制ブロックする設定にはしていない
- （持ち越し分）`sbi-pr-create`スキルにPR作成時のCopilot AI Credits消費量確認手順を追加

## 動作確認内容

- ローカルで `npm run typecheck` がエラーなしで通ることを確認
- ローカルで `npm run test` が8件パスすることを確認
- 本PRの作成自体で `ci-frontend.yml` が実際にActions上で動作するかを確認する

## DoDチェックリスト

- [x] SBIのDefinition of Doneを満たしている
- [x] 動作確認済み
- [ ] UI変更を含む場合、docs/design.md の配色・角丸・shadow・余白・タイポグラフィ規約に従っている（該当なし）
- [x] テキストに絵文字を使用していない
- [ ] Claude自動レビュー（`claude-code-review` ワークフロー）のコメントを確認し、指摘事項に対応または妥当性を判断した（Copilot自動レビューで代替）