### PR TITLE
[SBI #33] frontend既存lintエラー/警告を解消してnpm run lintを0件にする

### DIFF
--- a/frontend/app/admin/_AdminCalendarWrapper.tsx
+++ b/frontend/app/admin/_AdminCalendarWrapper.tsx
@@ -6,7 +6,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import { useSearchParams } from "next/navigation";
 import Calendar from "../../components/Calendar"; 
 import { useUser } from "../context/UserContext";
-import { api } from "@/lib/api"; // APIクライアントのインポート
+import { api, getErrorMessage } from "@/lib/api"; // APIクライアントのインポート
 
 // シフト状況の型定義
 interface ShiftStatus {
@@ -58,9 +58,9 @@ export default function AdminCalendarWrapper() {
                 });
             }
             setStatusData(dataMap);
-        } catch (err: any) {
+        } catch (err) {
             console.error("シフト状況取得エラー:", err);
-            setError(err.response?.data?.error || "シフト状況の取得に失敗しました。");
+            setError(getErrorMessage(err, "シフト状況の取得に失敗しました。"));
             setStatusData({}); // 失敗した場合はデータをクリア
         } finally {
             setIsLoading(false);

--- a/frontend/app/admin/day/[date]/_ShiftAdjustClient.tsx
+++ b/frontend/app/admin/day/[date]/_ShiftAdjustClient.tsx
@@ -3,7 +3,7 @@
 
 import React, { useEffect, useState, useCallback, useMemo } from "react";
 import Link from "next/link";
-import { api } from "@/lib/api";
+import { api, getErrorMessage } from "@/lib/api";
 import { format, parseISO } from 'date-fns';
 import { ja } from 'date-fns/locale';
 
@@ -102,8 +102,8 @@ export default function ShiftAdjustClient({ date }: { date: string }) {
                 }]
             }));
             setStaffData(initialData);
-        } catch (err: any) {
-            setError(err.response?.data?.error || "シフトデータの取得に失敗しました。");
+        } catch (err) {
+            setError(getErrorMessage(err, "シフトデータの取得に失敗しました。"));
             setStaffData([]);
         } finally {
             setLoading(false);
@@ -167,8 +167,8 @@ export default function ShiftAdjustClient({ date }: { date: string }) {
             setAutoMetrics(metrics);
             setShowMetrics(true);
             setMessage("自動調整の提案を表示しました。内容を確認して「シフトを確定する」を押してください。");
-        } catch (err: any) {
-            setError(err.response?.data?.error || "自動調整に失敗しました。");
+        } catch (err) {
+            setError(getErrorMessage(err, "自動調整に失敗しました。"));
         } finally {
             setAutoAdjusting(false);
         }
@@ -202,8 +202,8 @@ export default function ShiftAdjustClient({ date }: { date: string }) {
             setMessage(res.data.message || "シフト確定が完了しました。");
             setAutoMetrics(null);
             fetchShifts();
-        } catch (err: any) {
-            setError(err.response?.data?.error || "シフト確定に失敗しました。");
+        } catch (err) {
+            setError(getErrorMessage(err, "シフト確定に失敗しました。"));
         } finally {
             setLoading(false);
         }

--- a/frontend/app/admin/day/[date]/page.tsx
+++ b/frontend/app/admin/day/[date]/page.tsx
@@ -1,18 +1,17 @@
 // frontend/app/admin/day/[date]/page.tsx
 //"use client"
 
-import { useUser } from "@/app/context/UserContext";
 import ShiftAdjustClient from "./_ShiftAdjustClient"; // 新しいクライアントコンポーネントをインポート
 
-// パラメーターを受け取るための型定義
+// パラメーターを受け取るための型定義（Next.js 15ではparamsはPromise）
 interface PageProps {
-    params: {
+    params: Promise<{
         date: string; // YYYY-MM-DD
-    };
+    }>;
 }
 
 // サーバーコンポーネント: paramsを安全に取得し、クライアントコンポーネントに渡す
-export default async function AdminShiftAdjustPage(props: any) {
-    const { date } = props.params;
+export default async function AdminShiftAdjustPage(props: PageProps) {
+    const { date } = await props.params;
     return <ShiftAdjustClient date={date} />;
 }

--- a/frontend/app/admin/join_requests/page.tsx
+++ b/frontend/app/admin/join_requests/page.tsx
@@ -3,7 +3,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from "react";
-import { api } from "@/lib/api"; // あなたの axios インスタンスをインポート
+import { api, getErrorMessage } from "@/lib/api"; // あなたの axios インスタンスをインポート
 import { useUser } from "@/app/context/UserContext";
 
 // リクエストデータの型定義
@@ -35,8 +35,8 @@ export default function AdminJoinRequestsPage() {
         try {
             const res = await api.get("/join_requests");
             setRequests(res.data.requests);
-        } catch (err: any) {
-            const errorMessage = err.response?.data?.error || "リクエストの取得に失敗しました。";
+        } catch (err) {
+            const errorMessage = getErrorMessage(err, "リクエストの取得に失敗しました。");
             setError(errorMessage);
         } finally {
             setLoading(false);
@@ -68,8 +68,8 @@ export default function AdminJoinRequestsPage() {
             // 処理が成功したら、リストを更新するために再取得
             fetchRequests();
 
-        } catch (err: any) {
-            const errorMessage = err.response?.data?.error || "処理に失敗しました。";
+        } catch (err) {
+            const errorMessage = getErrorMessage(err, "処理に失敗しました。");
             setError(errorMessage);
             setMessage(null);
         }

--- a/frontend/app/edit_account/page.tsx
+++ b/frontend/app/edit_account/page.tsx
@@ -4,7 +4,7 @@
 
 import { useState } from "react";
 import { useUser } from "../context/UserContext";
-import { api } from "../../lib/api";
+import { api, getErrorMessage } from "../../lib/api";
 import { useRouter } from "next/navigation";
 
 export default function EditAccount() {
@@ -39,8 +39,8 @@ export default function EditAccount() {
       setUser(null);
       alert("アカウントは正常に削除されました。");
       router.push("/");
-    } catch (err: any) {
-      setMessage(err.response?.data?.error || "アカウントの削除に失敗しました");
+    } catch (err) {
+      setMessage(getErrorMessage(err, "アカウントの削除に失敗しました"));
     }
   };
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState } from "react";
 import { useRouter } from "next/navigation";
-import { api, TOKEN_STORAGE_KEY } from "../lib/api";
+import { api, TOKEN_STORAGE_KEY, getErrorMessage } from "../lib/api";
 import { useUser } from "./context/UserContext";
 
 export default function Login() {
@@ -28,8 +28,7 @@ export default function Login() {
       }
       router.push(res.data.user.role === "staff" ? "/staff" : "/admin");
     } catch (err) {
-      const error = err as any;
-      setError(error.response?.data?.error || "ログインに失敗しました");
+      setError(getErrorMessage(err, "ログインに失敗しました"));
     }
   };
 

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState } from "react";
 import { useRouter } from "next/navigation";
-import { api } from "../../lib/api";
+import { api, getErrorMessage } from "../../lib/api";
 import Link from "next/link";
 
 
@@ -23,8 +23,7 @@ export default function Register() {
       await api.post("/register", { name, email, password, role });
       router.push("/");
     } catch (err) {
-      const error = err as any;
-      setError(error.response?.data?.error || "登録に失敗しました");
+      setError(getErrorMessage(err, "登録に失敗しました"));
     }
   };
 

--- a/frontend/app/shifts/[date]/_ShiftViewClient.tsx
+++ b/frontend/app/shifts/[date]/_ShiftViewClient.tsx
@@ -4,7 +4,7 @@
 
 import React, { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
-import { api } from "@/lib/api";
+import { api, getErrorMessage } from "@/lib/api";
 import { useUser } from "@/app/context/UserContext"; // 認証・ユーザー情報取得用
 
 // -------------------- 型定義 --------------------
@@ -61,8 +61,8 @@ export default function ShiftViewClient({ date }: { date: string }) {
             // APIは { confirmed_shifts: [...] } の形式を想定
             setShifts(res.data.confirmed_shifts || []);
 
-        } catch (err: any) {
-            const errorMessage = err.response?.data?.error || "確定シフトの取得に失敗しました。";
+        } catch (err) {
+            const errorMessage = getErrorMessage(err, "確定シフトの取得に失敗しました。");
             setError(errorMessage);
             setShifts([]);
         } finally {

--- a/frontend/app/shifts/[date]/page.tsx
+++ b/frontend/app/shifts/[date]/page.tsx
@@ -3,19 +3,19 @@
 
 import ShiftViewClient from "./_ShiftViewClient"; 
 
-// パラメーターを受け取るための型定義
+// パラメーターを受け取るための型定義（Next.js 15ではparamsはPromise）
 interface PageProps {
-    params: {
+    params: Promise<{
         date: string; // YYYY-MM-DD
-    };
+    }>;
 }
 
 /**
  * スタッフ向け確定シフト確認ページ (Server Component)
  * URLから日付パラメータを取得し、クライアントコンポーネントに渡します。
  */
-export default function StaffShiftViewPage(props: any) {
-    const { date } = props.params;
+export default async function StaffShiftViewPage(props: PageProps) {
+    const { date } = await props.params;
 
     // クライアントコンポーネントに date だけを渡す
     return <ShiftViewClient date={date} />;

--- a/frontend/app/shifts/_ShiftCalendarClient.tsx
+++ b/frontend/app/shifts/_ShiftCalendarClient.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 import { useUser } from '@/app/context/UserContext';
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, isSameDay, parseISO } from 'date-fns';
 import { ja } from 'date-fns/locale';
-import { api } from "@/lib/api";
+import { api, getErrorMessage } from "@/lib/api";
 import Link from 'next/link';
 
 // -------------------- 型定義 --------------------
@@ -69,7 +69,7 @@ export default function ShiftCalendarClient({ initialYear, initialMonth }: Props
     try {
       const res = await api.get(`/shifts/month/${y}/${m}`);
       setShiftsByDate(res.data.shifts_by_date || {});
-    } catch (err: any) {
+    } catch {
       setError('データの取得に失敗しました。');
     } finally {
       setIsLoading(false);
@@ -145,8 +145,8 @@ export default function ShiftCalendarClient({ initialYear, initialMonth }: Props
       await fetchShifts(year, month);
       // 提出後は詳細モードに切替
       setPanelMode('detail');
-    } catch (err: any) {
-      setSubmitMessage(`失敗: ${err.response?.data?.error ?? 'サーバーエラー'}`);
+    } catch (err) {
+      setSubmitMessage(`失敗: ${getErrorMessage(err, 'サーバーエラー')}`);
     } finally {
       setSubmitting(false);
     }
@@ -412,10 +412,6 @@ export default function ShiftCalendarClient({ initialYear, initialMonth }: Props
                     const isSelected = selectedDate === dateStr;
                     const isPast = day.getTime() < new Date().setHours(0, 0, 0, 0);
                     const dow = day.getDay();
-                    const shifts = shiftsByDate[dateStr] ?? [];
-                    const hasConfirmed = shifts.some(s => s.shift_type === 'confirmed');
-                    const hasRequest = shifts.some(s => s.shift_type === 'request');
-
                     return (
                       <button
                         key={dateStr}

--- a/frontend/app/shifts/monthly-summary/page.tsx
+++ b/frontend/app/shifts/monthly-summary/page.tsx
@@ -2,10 +2,10 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, useMemo, Suspense } from 'react';
-import { useSearchParams, useRouter } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { useUser } from '@/app/context/UserContext';
 import { api } from '@/lib/api';
-import { format, parseISO, eachDayOfInterval, startOfMonth, endOfMonth } from 'date-fns';
+import { format, eachDayOfInterval, startOfMonth, endOfMonth } from 'date-fns';
 import { ja } from 'date-fns/locale';
 import Link from 'next/link';
 
@@ -39,7 +39,6 @@ const formatDuration = (start: string, end: string) => {
 // -------------------- 内部コンポーネント --------------------
 function MonthlySummaryContent() {
   const searchParams = useSearchParams();
-  const router = useRouter();
   const { user, loading: userLoading } = useUser();
 
   const now = new Date();

--- a/frontend/app/shop/[shopId]/auto-adjust/page.tsx
+++ b/frontend/app/shop/[shopId]/auto-adjust/page.tsx
@@ -3,7 +3,7 @@
  
 import React, { useState, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
-import { api } from "../../../../lib/api";
+import { api, getErrorMessage } from "../../../../lib/api";
 import { useUser } from "../../../context/UserContext";
 import Link from "next/link";
  
@@ -47,7 +47,7 @@ export default function AutoAdjustSettingsPage() {
   const [staffList, setStaffList] = useState<StaffUser[]>([]);
   const [priorities, setPriorities] = useState<PrioritiesMap>({});
   const [capacities, setCapacities] = useState<CapacitiesMap>({});
-  const [options, setOptions] = useState<Record<string, any>>({});
+  const [options, setOptions] = useState<Record<string, unknown>>({});
   const [histories, setHistories] = useState<RejectionHistory[]>([]);
  
   const [loading, setLoading] = useState(true);
@@ -114,8 +114,8 @@ export default function AutoAdjustSettingsPage() {
       });
       setMessage("設定を保存しました");
       setMessageType("success");
-    } catch (err: any) {
-      setMessage(err.response?.data?.error || "保存に失敗しました");
+    } catch (err) {
+      setMessage(getErrorMessage(err, "保存に失敗しました"));
       setMessageType("error");
     } finally {
       setSaving(false);
@@ -130,8 +130,8 @@ export default function AutoAdjustSettingsPage() {
       setMessage("棄却履歴をリセットしました");
       setMessageType("success");
       await fetchData();
-    } catch (err: any) {
-      setMessage(err.response?.data?.error || "リセットに失敗しました");
+    } catch (err) {
+      setMessage(getErrorMessage(err, "リセットに失敗しました"));
       setMessageType("error");
     } finally {
       setResetting(false);

--- a/frontend/app/shop/[shopId]/page.tsx
+++ b/frontend/app/shop/[shopId]/page.tsx
@@ -3,7 +3,7 @@
 
 import React, { useState, useEffect } from "react";
 import { useRouter, useParams } from "next/navigation";
-import { api } from "../../../lib/api";
+import { api, getErrorMessage } from "../../../lib/api";
 import { useUser } from "../../context/UserContext";
 import Link from "next/link";
 
@@ -35,7 +35,6 @@ export default function ShopDetail() {
 
   // 設定ローディング
   const [configLoading, setConfigLoading] = useState(false);
-  const [configSaved, setConfigSaved] = useState(false);
 
   const isAdmin = user?.role === "admin";
 
@@ -105,8 +104,8 @@ export default function ShopDetail() {
       });
       setMessage("店舗情報を更新しました");
       setMessageType("success");
-    } catch (err: any) {
-      setMessage(err.response?.data?.error || "更新に失敗しました");
+    } catch (err) {
+      setMessage(getErrorMessage(err, "更新に失敗しました"));
       setMessageType("error");
     }
   };
@@ -114,7 +113,6 @@ export default function ShopDetail() {
   // 営業時間・定員保存
   const handleConfigSave = async () => {
     setConfigLoading(true);
-    setConfigSaved(false);
     try {
       // 既存のprioritiesを取得してマージ
       const cfgRes = await api.get(`/shop/${shopId}/auto_adjust/config`);
@@ -125,11 +123,10 @@ export default function ShopDetail() {
         capacities,
         options: { open_hour: openHour, close_hour: closeHour },
       });
-      setConfigSaved(true);
       setMessage("営業時間・定員設定を保存しました");
       setMessageType("success");
-    } catch (err: any) {
-      setMessage(err.response?.data?.error || "設定の保存に失敗しました");
+    } catch (err) {
+      setMessage(getErrorMessage(err, "設定の保存に失敗しました"));
       setMessageType("error");
     } finally {
       setConfigLoading(false);

--- a/frontend/app/shop_register/page.tsx
+++ b/frontend/app/shop_register/page.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { api } from "../../lib/api";
+import { api, getErrorMessage } from "../../lib/api";
 import { useRouter } from "next/navigation"; 
 
 export default function ShopRegister() {
@@ -30,8 +30,7 @@ export default function ShopRegister() {
       }
 
     } catch (err) {
-      const error = err as any;
-      setMessage(error.response?.data?.error || "登録に失敗しました");
+      setMessage(getErrorMessage(err, "登録に失敗しました"));
     }
   };
 

--- a/frontend/app/staff_shop_register/page.tsx
+++ b/frontend/app/staff_shop_register/page.tsx
@@ -3,13 +3,13 @@
 "use client";
 
 import React, { useState } from "react";
-import { api } from "../../lib/api";
+import { api, getErrorMessage } from "../../lib/api";
 import { useUser } from "../context/UserContext";
 
 export default function StaffShopRequest() {
   const [shopCode, setShopCode] = useState("");
   const [message, setMessage] = useState("");
-  const { user, refreshUser } = useUser();
+  const { refreshUser } = useUser();
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -24,9 +24,8 @@ export default function StaffShopRequest() {
       await refreshUser();
       
     } catch (err) {
-      const error = err as any; 
-      const errorMessage = error.response?.data?.error || "リクエスト送信に失敗しました";
-      console.error(err); 
+      const errorMessage = getErrorMessage(err, "リクエスト送信に失敗しました");
+      console.error(err);
       setMessage(errorMessage);
     }
   };

--- a/frontend/components/Calendar.tsx
+++ b/frontend/components/Calendar.tsx
@@ -50,7 +50,7 @@ export default function Calendar({ base_path, current_page_path, statusData = {}
         const daysArray: Day[] = [];
 
         // 前月の日付の空欄を埋める (0=日, 1=月, ..., 6=土)
-        let startDayOfWeek = firstDay.getDay();
+        const startDayOfWeek = firstDay.getDay();
         for (let i = 0; i < startDayOfWeek; i++) {
             // month: 0 は前月・次月の空欄として使用
             daysArray.push({ day: "", month: 0, dateStr: "" }); 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -21,3 +21,13 @@ api.interceptors.request.use((config) => {
   }
   return config;
 });
+
+// APIエラーレスポンス（{ "error": "..." }）からメッセージを取り出す共通ヘルパー。
+// axios以外の例外やレスポンス形式が想定外の場合はfallbackを返す。
+export function getErrorMessage(err: unknown, fallback: string): string {
+  if (axios.isAxiosError(err)) {
+    const data = err.response?.data as { error?: string } | undefined;
+    return data?.error || fallback;
+  }
+  return fallback;
+}


### PR DESCRIPTION
## 関連Issue

Closes #33
関連PBI: #32

## 変更内容

- `frontend/lib/api.ts` に共通ヘルパー `getErrorMessage(err, fallback)` を追加し、`catch (err: any) { err.response?.data?.error }` パターン（18箇所）を集約
- Next.js 15のasync params移行漏れを発見・修正: `app/admin/day/[date]/page.tsx`・`app/shifts/[date]/page.tsx` の `props: any` を `PageProps` に直したところ、`params` が実際には `Promise` である型契約と不整合でbuildが壊れることが判明。`params: Promise<{date: string}>` + `await` に修正（元の `any` はこの不整合を隠していただけだった）
- 未使用import・未使用変数（`useUser`, `parseISO`, `router`, `configSaved`, `hasConfirmed`/`hasRequest` 等）を削除。いずれも実際に読まれていないデッドコードであることを確認済み
- `Record<string, any>` を `Record<string, unknown>` に（backend側も未構造化JSONのため誠実な型）
- `prefer-const` 1件を修正

## 動作確認内容

- `npm run lint` が0件でパスすることを確認
- `npm run typecheck` が0件でパスすることを確認
- `npm run test` が8件全てパスすることを確認
- `npm run build` が成功することを確認（Next.js 15のasync params修正込みで、14ルート全て正常に生成）

## DoDチェックリスト

- [x] SBIのDefinition of Doneを満たしている
- [x] 動作確認済み
- [ ] UI変更を含む場合、docs/design.md の配色・角丸・shadow・余白・タイポグラフィ規約に従っている（該当なし、見た目は変更していない）
- [x] テキストに絵文字を使用していない
- [ ] Claude自動レビュー（`claude-code-review` ワークフロー）のコメントを確認し、指摘事項に対応または妥当性を判断した（Copilot自動レビューで代替）