### PR TITLE
chore: docker-compose.ymlのfrontendビルドが常にAPI接続不能になる不具合を修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,11 @@ services:
     build:
       context: ./frontend # ビルドコンテキストを指定
       dockerfile: Dockerfile # Dockerfile名も指定しとくと明確
+      args:
+        # NEXT_PUBLIC_*はnext build時に静的に埋め込まれるため、buildのargsとして渡す必要がある
+        # （environmentだけだとビルド後のランタイムにしか効かず、ブラウザ向けバンドルには反映されない）
+        # ブラウザから直接叩くURLなので、コンテナ内のサービス名(backend)ではなくlocalhostを指定する
+        NEXT_PUBLIC_API_BASE_URL: http://localhost:5000/api
     container_name: shift_app_frontend
     ports:
       - "3000:3000"
@@ -42,7 +47,7 @@ services:
       #- ./frontend:/app
       #- /app/node_modules # node_modulesはコンテナ内でインストールしたものを使うように除外
     environment:
-      - NEXT_PUBLIC_API_BASE_URL=http://backend:5000 
+      - NEXT_PUBLIC_API_BASE_URL=http://localhost:5000/api
       - HOST=0.0.0.0
     depends_on:
       - backend # バックエンドが起動してからフロントエンドを起動

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,6 +12,11 @@ RUN npm install
 # 全てのファイルをコピー
 COPY . .
 
+# NEXT_PUBLIC_*はnext build時にクライアントバンドルへ静的に埋め込まれるため、
+# ビルド前にARGからENVへ反映しておく必要がある
+ARG NEXT_PUBLIC_API_BASE_URL
+ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
+
 # Next.jsアプリを本番用にビルド
 RUN npm run build
 


### PR DESCRIPTION
## 関連Issue

特定のSBI/PBIに紐づかない、開発環境の実動作確認中に見つかった不具合修正（PR #41の続き）。

## 変更内容

- `frontend/Dockerfile`: `NEXT_PUBLIC_API_BASE_URL`を`next build`前に受け取るための`ARG`/`ENV`を追加
  - Next.jsの`NEXT_PUBLIC_*`はビルド時にクライアントバンドルへ静的に埋め込まれるため、`docker-compose.yml`の`environment:`（ランタイムにしか効かない）だけでは反映されず、値が未定義のまま焼き込まれていた
- `docker-compose.yml`: `frontend.build.args`で正しい値を渡すよう追加。値も`http://backend:5000`（ブラウザからは名前解決できないDocker内部ホスト名）から`http://localhost:5000/api`に修正

## 動作確認内容

- `docker compose up -d --build` で実際にビルド・起動
- ブラウザで `admin`/`pass` でログイン→管理画面（シフトカレンダー）表示まで確認
- 確認後、`docker compose down` でコンテナを片付け済み

## DoDチェックリスト

- [x] 動作確認済み（ブラウザで実際にビルドからログインまで確認）
- [ ] UI変更を含む場合、docs/design.md の配色・角丸・shadow・余白・タイポグラフィ規約に従っている（該当なし）
- [x] テキストに絵文字を使用していない
- [ ] Claude自動レビュー（`claude-code-review` ワークフロー）のコメントを確認し、指摘事項に対応または妥当性を判断した（Copilotのクオータ状況次第）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPwqvLGtj7P7JuXVSk9sas